### PR TITLE
Replace `checkuser()` with `reportip()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Report IP Address
 ```js
 const wrapper = require('raylen.js')
 
-wrapper.checkuser("IP Address", "API KEY", "REASON", "Category").then(data => console.log(data))
+wrapper.reportip("IP Address", "API KEY", "REASON", "Category").then(data => console.log(data))
 ```


### PR DESCRIPTION
Apparently, [`reportip()`](https://github.com/ausername-1/raylen.js/blob/841aec99892e002f1e67aa7876d248f9c2cdbc55/index.js#L12) is the function to use for reporting, while [`checkuser()`](https://github.com/ausername-1/raylen.js/search?q=checkuser) doesn't exist anywhere else.